### PR TITLE
fix ReadAt EOF issue

### DIFF
--- a/disk/disk.go
+++ b/disk/disk.go
@@ -23,6 +23,11 @@ type Disk struct {
 func (d *Disk) ReadAt(name string, p []byte, off int64) (int, error) {
 	name = path.Join(d.Root, name)
 
+	// nil or zero length payload
+	if len(p) == 0 {
+		return 0, nil
+	}
+
 	// block size
 	bsize := blockSize(name)
 	// payload size
@@ -51,7 +56,7 @@ func (d *Disk) ReadAt(name string, p []byte, off int64) (int, error) {
 		// 1. There is an error reading block
 		// 2. We read a partial block -- reach the end of the file
 		// 3. We can't copy into p anymore -- p is filled up
-		if err != nil || n < bsize-crc32Len || copied == 0 {
+		if err != nil || n < bsize-crc32Len || len(p) == 0 {
 			return read + copied, err
 		}
 		read += copied


### PR DESCRIPTION
The cause of the issue is `p` length is already 0 and then we do another `readBlock` and `copy` get `0` and we return since `copied` is 0, so if the last unneeded `readBlock` returns EOF, we return an EOF we should not return.
