### PR TITLE
readBlock: don't return error if input buffer is smaller than a block

### DIFF
--- a/disk/block_test.go
+++ b/disk/block_test.go
@@ -107,7 +107,7 @@ func TestReadWriteBlock(t *testing.T) {
 		// write partly block
 		{90, 20, 4, 16},
 		// empty data
-		{100, 20, 0, 0},
+		{0, 20, 0, 0},
 		// empty data with just fit block size
 		{100, 4, 0, 0},
 	}
@@ -122,6 +122,8 @@ func TestReadWriteBlock(t *testing.T) {
 		{20, 20, 0, 40, ErrPayloadSizeTooLarge},
 		// too small block size
 		{20, 1, 0, 0, ErrPayloadSizeTooLarge},
+		// CRC error since it is appending to the last piece of the block
+		{100, 20, 0, 0, ErrBadCRC},
 		// negative index
 		{20, 20, -1, 16, errors.New("invalid argument")},
 	}


### PR DESCRIPTION
If there is a full block and the client is reading half of them,
we should first read the full block out, compare the crc, then
copy data into client buffer.
@yutongp @wangtuanjie 
