### PR TITLE
fix erasure.go cgo import

### DIFF
--- a/erasure/erasure.go
+++ b/erasure/erasure.go
@@ -1,6 +1,7 @@
 package erasure
 
-import _ "github.com/cfs/Jerasure"
+import _ "github.com/c-fs/Jerasure"
+
 // #include "jerasure.h"
 // #include "cauchy.h"
 // #cgo CXXFLAGS: -std=c++11


### PR DESCRIPTION
error msg: `erasure.go:3:8: cannot find package "github.com/cfs/Jerasure"`

I assume our root dir is "github.com/c-fs" not "github.com/cfs"
