### PR TITLE
Split error tests into read and write

### DIFF
--- a/disk/block_test.go
+++ b/disk/block_test.go
@@ -81,6 +81,9 @@ func TestCRCErrCheck(t *testing.T) {
 		{20, 10, 1},
 		// small file (no crc)
 		{2, 10, 0},
+		// CRC error since it is appending to the last piece of the block
+		{100, 10, 0},
+
 	}
 	defer os.Remove(tmpTestFile)
 	p := make([]byte, 6)
@@ -122,8 +125,6 @@ func TestReadWriteBlock(t *testing.T) {
 		{20, 20, 0, 40, ErrPayloadSizeTooLarge},
 		// too small block size
 		{20, 1, 0, 0, ErrPayloadSizeTooLarge},
-		// CRC error since it is appending to the last piece of the block
-		{100, 20, 0, 0, ErrBadCRC},
 		// negative index
 		{20, 20, -1, 16, errors.New("invalid argument")},
 	}


### PR DESCRIPTION
Some errors only show up when read
