### PR TITLE
server: print disk.writeAt error when calling write func

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -30,8 +30,12 @@ func (s *server) Write(ctx context.Context, req *pb.WriteRequest) (*pb.WriteRepl
 		return &pb.WriteReply{}, nil
 	}
 
-	n, _ := d.WriteAt(fn, req.Data, req.Offset)
+	n, err := d.WriteAt(fn, req.Data, req.Offset)
 	// TODO: add error
+	if err != nil {
+		log.Infof("server: write error (%v)", err)
+		return &pb.WriteReply{}, nil
+	}
 	reply := &pb.WriteReply{BytesWritten: int64(n)}
 	return reply, nil
 }


### PR DESCRIPTION
The server side will print out error like this:

```
2015/06/03 05:57:52 [INFO][github.com/c-fs/cfs/server] server.go:36:
server: write error (open cfs0000/foodir/foo: no such file or directory)
```

fixes #48 
