### PR TITLE
add Makefile for `go test` and `go vet`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+########################################
+# cfs
+########################################
+
+ORG_PATH:=github.com/c-fs
+REPO_PATH:=$(ORG_PATH)/cfs
+
+$(eval TEST := $(shell cd ../../.. && find $(REPO_PATH) -name '*_test.go' |  xargs -L 1 dirname | uniq | sort))
+
+.PHONY: build
+# TODO
+
+.PHONY: test
+test: go-vet build
+	go test -p 8 -race $(TEST)
+
+.PHONY: go-vet
+go-vet:
+	@find . -name '*.go' | xargs -L 1 go tool vet


### PR DESCRIPTION
I think we are still debating on whether we need Makefile or not.

I like one command to test and vet all pkgs though.
