### PR TITLE
*: introduce client concept

### DIFF
--- a/cfsctl/cfs_command.go
+++ b/cfsctl/cfs_command.go
@@ -39,7 +39,7 @@ func addCommand() {
 
 func setUpClient() *client.Client {
 	// Set up a connection to the server.
-	c, err := client.New(address)
+	c, err := client.New("cfsctl", address)
 	if err != nil {
 		log.Fatalf("Cannot create cfs client: %v", err)
 	}

--- a/cfsctl/cfs_command.go
+++ b/cfsctl/cfs_command.go
@@ -39,7 +39,7 @@ func addCommand() {
 
 func setUpClient() *client.Client {
 	// Set up a connection to the server.
-	c, err := client.New("cfsctl", address)
+	c, err := client.New(0x1234, address)
 	if err != nil {
 		log.Fatalf("Cannot create cfs client: %v", err)
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -15,8 +15,8 @@ type Client struct {
 	statsClient pb.StatsClient
 }
 
-func New(name, address string) (*Client, error) {
-	header := &pb.RequestHeader{Client: name}
+func New(clientID int64, address string) (*Client, error) {
+	header := &pb.RequestHeader{ClientID: clientID}
 	conn, err := grpc.Dial(address)
 	if err != nil {
 		return nil, err

--- a/client/client.go
+++ b/client/client.go
@@ -9,12 +9,14 @@ import (
 )
 
 type Client struct {
+	header      *pb.RequestHeader
 	grpcConn    *grpc.ClientConn
 	fileClient  pb.CfsClient
 	statsClient pb.StatsClient
 }
 
-func New(address string) (*Client, error) {
+func New(name, address string) (*Client, error) {
+	header := &pb.RequestHeader{Client: name}
 	conn, err := grpc.Dial(address)
 	if err != nil {
 		return nil, err
@@ -22,13 +24,13 @@ func New(address string) (*Client, error) {
 	fc := pb.NewCfsClient(conn)
 	sc := pb.NewStatsClient(conn)
 
-	return &Client{grpcConn: conn, fileClient: fc, statsClient: sc}, nil
+	return &Client{header: header, grpcConn: conn, fileClient: fc, statsClient: sc}, nil
 }
 
 func (c *Client) Write(ctx context.Context, name string, offset int64, data []byte, isAppend bool) (int64, error) {
 	reply, err := c.fileClient.Write(
 		ctx,
-		&pb.WriteRequest{Name: name, Offset: offset, Data: data, Append: isAppend},
+		&pb.WriteRequest{Header: c.header, Name: name, Offset: offset, Data: data, Append: isAppend},
 	)
 
 	if err != nil {
@@ -42,7 +44,7 @@ func (c *Client) Read(ctx context.Context, name string, offset, length int64, ch
 	reply, err := c.fileClient.Read(
 		ctx,
 		&pb.ReadRequest{
-			Name: name, Offset: offset, Length: length, ExpChecksum: checksum,
+			Header: c.header, Name: name, Offset: offset, Length: length, ExpChecksum: checksum,
 		},
 	)
 
@@ -55,7 +57,7 @@ func (c *Client) Read(ctx context.Context, name string, offset, length int64, ch
 func (c *Client) Rename(ctx context.Context, oldName, newName string) error {
 	reply, err := c.fileClient.Rename(
 		ctx,
-		&pb.RenameRequest{Oldname: oldName, Newname: newName},
+		&pb.RenameRequest{Header: c.header, Oldname: oldName, Newname: newName},
 	)
 
 	if err != nil {
@@ -65,7 +67,7 @@ func (c *Client) Rename(ctx context.Context, oldName, newName string) error {
 }
 
 func (c *Client) Remove(ctx context.Context, name string, all bool) error {
-	reply, err := c.fileClient.Remove(ctx, &pb.RemoveRequest{Name: name, All: all})
+	reply, err := c.fileClient.Remove(ctx, &pb.RemoveRequest{Header: c.header, Name: name, All: all})
 
 	if err != nil {
 		return err
@@ -74,7 +76,7 @@ func (c *Client) Remove(ctx context.Context, name string, all bool) error {
 }
 
 func (c *Client) ReadDir(ctx context.Context, name string) ([]*pb.FileInfo, error) {
-	reply, err := c.fileClient.ReadDir(ctx, &pb.ReadDirRequest{Name: name})
+	reply, err := c.fileClient.ReadDir(ctx, &pb.ReadDirRequest{Header: c.header, Name: name})
 
 	if err != nil {
 		return nil, err
@@ -83,7 +85,7 @@ func (c *Client) ReadDir(ctx context.Context, name string) ([]*pb.FileInfo, erro
 }
 
 func (c *Client) Mkdir(ctx context.Context, name string, all bool) error {
-	reply, err := c.fileClient.Mkdir(ctx, &pb.MkdirRequest{Name: name, All: all})
+	reply, err := c.fileClient.Mkdir(ctx, &pb.MkdirRequest{Header: c.header, Name: name, All: all})
 
 	if err != nil {
 		return err

--- a/proto/file.pb.go
+++ b/proto/file.pb.go
@@ -10,6 +10,7 @@ It is generated from these files:
 	stats.proto
 
 It has these top-level messages:
+	RequestHeader
 	PathError
 	SyscallError
 	Error
@@ -46,6 +47,14 @@ var _ grpc.ClientConn
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto1.Marshal
+
+type RequestHeader struct {
+	Client string `protobuf:"bytes,1,opt,name=client" json:"client,omitempty"`
+}
+
+func (m *RequestHeader) Reset()         { *m = RequestHeader{} }
+func (m *RequestHeader) String() string { return proto1.CompactTextString(m) }
+func (*RequestHeader) ProtoMessage()    {}
 
 // PathError records an error and the operation and file path that caused it.
 type PathError struct {
@@ -108,15 +117,23 @@ func (*FileInfo) ProtoMessage()    {}
 // of bytes written and an error, if any.
 // Write returns an error when n != len(b).
 type WriteRequest struct {
-	Name   string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	Offset int64  `protobuf:"varint,2,opt,name=offset" json:"offset,omitempty"`
-	Data   []byte `protobuf:"bytes,3,opt,name=data,proto3" json:"data,omitempty"`
-	Append bool   `protobuf:"varint,4,opt,name=append" json:"append,omitempty"`
+	Header *RequestHeader `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
+	Name   string         `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
+	Offset int64          `protobuf:"varint,3,opt,name=offset" json:"offset,omitempty"`
+	Data   []byte         `protobuf:"bytes,4,opt,name=data,proto3" json:"data,omitempty"`
+	Append bool           `protobuf:"varint,5,opt,name=append" json:"append,omitempty"`
 }
 
 func (m *WriteRequest) Reset()         { *m = WriteRequest{} }
 func (m *WriteRequest) String() string { return proto1.CompactTextString(m) }
 func (*WriteRequest) ProtoMessage()    {}
+
+func (m *WriteRequest) GetHeader() *RequestHeader {
+	if m != nil {
+		return m.Header
+	}
+	return nil
+}
 
 type WriteReply struct {
 	Error        *Error `protobuf:"bytes,1,opt,name=error" json:"error,omitempty"`
@@ -136,15 +153,23 @@ func (m *WriteReply) GetError() *Error {
 
 // Read reads up to length bytes. The checksum of the data must match the exp_checksum if given, or an error is returned.
 type ReadRequest struct {
-	Name        string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	Offset      int64  `protobuf:"varint,2,opt,name=offset" json:"offset,omitempty"`
-	Length      int64  `protobuf:"varint,3,opt,name=length" json:"length,omitempty"`
-	ExpChecksum uint32 `protobuf:"fixed32,4,opt,name=exp_checksum" json:"exp_checksum,omitempty"`
+	Header      *RequestHeader `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
+	Name        string         `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
+	Offset      int64          `protobuf:"varint,3,opt,name=offset" json:"offset,omitempty"`
+	Length      int64          `protobuf:"varint,4,opt,name=length" json:"length,omitempty"`
+	ExpChecksum uint32         `protobuf:"fixed32,5,opt,name=exp_checksum" json:"exp_checksum,omitempty"`
 }
 
 func (m *ReadRequest) Reset()         { *m = ReadRequest{} }
 func (m *ReadRequest) String() string { return proto1.CompactTextString(m) }
 func (*ReadRequest) ProtoMessage()    {}
+
+func (m *ReadRequest) GetHeader() *RequestHeader {
+	if m != nil {
+		return m.Header
+	}
+	return nil
+}
 
 type ReadReply struct {
 	Error     *Error `protobuf:"bytes,1,opt,name=error" json:"error,omitempty"`
@@ -165,13 +190,21 @@ func (m *ReadReply) GetError() *Error {
 }
 
 type RenameRequest struct {
-	Oldname string `protobuf:"bytes,1,opt,name=oldname" json:"oldname,omitempty"`
-	Newname string `protobuf:"bytes,2,opt,name=newname" json:"newname,omitempty"`
+	Header  *RequestHeader `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
+	Oldname string         `protobuf:"bytes,2,opt,name=oldname" json:"oldname,omitempty"`
+	Newname string         `protobuf:"bytes,3,opt,name=newname" json:"newname,omitempty"`
 }
 
 func (m *RenameRequest) Reset()         { *m = RenameRequest{} }
 func (m *RenameRequest) String() string { return proto1.CompactTextString(m) }
 func (*RenameRequest) ProtoMessage()    {}
+
+func (m *RenameRequest) GetHeader() *RequestHeader {
+	if m != nil {
+		return m.Header
+	}
+	return nil
+}
 
 type RenameReply struct {
 	Error *Error `protobuf:"bytes,1,opt,name=error" json:"error,omitempty"`
@@ -189,12 +222,20 @@ func (m *RenameReply) GetError() *Error {
 }
 
 type ReadDirRequest struct {
-	Name string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	Header *RequestHeader `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
+	Name   string         `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
 }
 
 func (m *ReadDirRequest) Reset()         { *m = ReadDirRequest{} }
 func (m *ReadDirRequest) String() string { return proto1.CompactTextString(m) }
 func (*ReadDirRequest) ProtoMessage()    {}
+
+func (m *ReadDirRequest) GetHeader() *RequestHeader {
+	if m != nil {
+		return m.Header
+	}
+	return nil
+}
 
 type ReadDirReply struct {
 	Error     *Error      `protobuf:"bytes,1,opt,name=error" json:"error,omitempty"`
@@ -221,15 +262,23 @@ func (m *ReadDirReply) GetFileInfos() []*FileInfo {
 
 // Remove removes the named file or directory. If there is an error, it will be of type *PathError.
 type RemoveRequest struct {
-	Name string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	Header *RequestHeader `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
+	Name   string         `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
 	// All removes path and any children it contains. It removes everything it can but returns the first error it
 	// encounters. If the path does not exist, RemoveAll returns nil (no error).
-	All bool `protobuf:"varint,2,opt,name=all" json:"all,omitempty"`
+	All bool `protobuf:"varint,3,opt,name=all" json:"all,omitempty"`
 }
 
 func (m *RemoveRequest) Reset()         { *m = RemoveRequest{} }
 func (m *RemoveRequest) String() string { return proto1.CompactTextString(m) }
 func (*RemoveRequest) ProtoMessage()    {}
+
+func (m *RemoveRequest) GetHeader() *RequestHeader {
+	if m != nil {
+		return m.Header
+	}
+	return nil
+}
 
 type RemoveReply struct {
 	Error *Error `protobuf:"bytes,1,opt,name=error" json:"error,omitempty"`
@@ -249,13 +298,21 @@ func (m *RemoveReply) GetError() *Error {
 // Mkdir creates a new directory with the specified name. If all is set, Mkdir creates a directory named path,
 // along with any necessary parents. If path is already a directory, Mkdir does nothing.
 type MkdirRequest struct {
-	Name string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	All  bool   `protobuf:"varint,2,opt,name=all" json:"all,omitempty"`
+	Header *RequestHeader `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
+	Name   string         `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
+	All    bool           `protobuf:"varint,3,opt,name=all" json:"all,omitempty"`
 }
 
 func (m *MkdirRequest) Reset()         { *m = MkdirRequest{} }
 func (m *MkdirRequest) String() string { return proto1.CompactTextString(m) }
 func (*MkdirRequest) ProtoMessage()    {}
+
+func (m *MkdirRequest) GetHeader() *RequestHeader {
+	if m != nil {
+		return m.Header
+	}
+	return nil
+}
 
 type MkdirReply struct {
 	Error *Error `protobuf:"bytes,1,opt,name=error" json:"error,omitempty"`
@@ -273,30 +330,47 @@ func (m *MkdirReply) GetError() *Error {
 }
 
 type ReconstructSrc struct {
-	Remote string `protobuf:"bytes,1,opt,name=remote" json:"remote,omitempty"`
-	Name   string `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
+	Header *RequestHeader `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
+	Remote string         `protobuf:"bytes,2,opt,name=remote" json:"remote,omitempty"`
+	Name   string         `protobuf:"bytes,3,opt,name=name" json:"name,omitempty"`
 }
 
 func (m *ReconstructSrc) Reset()         { *m = ReconstructSrc{} }
 func (m *ReconstructSrc) String() string { return proto1.CompactTextString(m) }
 func (*ReconstructSrc) ProtoMessage()    {}
 
+func (m *ReconstructSrc) GetHeader() *RequestHeader {
+	if m != nil {
+		return m.Header
+	}
+	return nil
+}
+
 type ReconstructDst struct {
+	Header *RequestHeader `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
 	// The destination should always be local server.
-	Name string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	Name string `protobuf:"bytes,2,opt,name=name" json:"name,omitempty"`
 }
 
 func (m *ReconstructDst) Reset()         { *m = ReconstructDst{} }
 func (m *ReconstructDst) String() string { return proto1.CompactTextString(m) }
 func (*ReconstructDst) ProtoMessage()    {}
 
+func (m *ReconstructDst) GetHeader() *RequestHeader {
+	if m != nil {
+		return m.Header
+	}
+	return nil
+}
+
 // http://web.eecs.utk.edu/~plank/plank/papers/2013-02-11-FAST-Tutorial.pdf
 // https://www.usenix.org/legacy/events/fast09/tech/full_papers/plank/plank_html/
 // Optimized for Cauchy Reed-Solomon (CRS) Codes, but should also be applied to
 // RAID5 and RAID6
 type ReconstructRequest struct {
-	Srcs []*ReconstructSrc `protobuf:"bytes,1,rep,name=srcs" json:"srcs,omitempty"`
-	Dsts []*ReconstructDst `protobuf:"bytes,2,rep,name=dsts" json:"dsts,omitempty"`
+	Header *RequestHeader    `protobuf:"bytes,1,opt,name=header" json:"header,omitempty"`
+	Srcs   []*ReconstructSrc `protobuf:"bytes,2,rep,name=srcs" json:"srcs,omitempty"`
+	Dsts   []*ReconstructDst `protobuf:"bytes,3,rep,name=dsts" json:"dsts,omitempty"`
 	// each src has multiple strips. the length of src must be
 	// a multiply of stripe_size or it should be zero filled.
 	//
@@ -305,20 +379,27 @@ type ReconstructRequest struct {
 	// w MUST be in the range [1, 32]
 	//
 	// https://www.usenix.org/legacy/events/fast09/tech/full_papers/plank/plank_html Section 2.2
-	StripSize  int32 `protobuf:"varint,3,opt,name=strip_size" json:"strip_size,omitempty"`
-	PacketSize int32 `protobuf:"varint,4,opt,name=packet_size" json:"packet_size,omitempty"`
-	W          int32 `protobuf:"varint,5,opt,name=w" json:"w,omitempty"`
+	StripSize  int32 `protobuf:"varint,4,opt,name=strip_size" json:"strip_size,omitempty"`
+	PacketSize int32 `protobuf:"varint,5,opt,name=packet_size" json:"packet_size,omitempty"`
+	W          int32 `protobuf:"varint,6,opt,name=w" json:"w,omitempty"`
 	// wk * wn matrix of bits
 	// k is the number of sources, n is the number of dests.
 	// bit_matrix[i][j] = i * k * w + j
 	// TODO: make this a dense bytes array and each bytes contains
 	// 8 bits.
-	BitMatrix []int32 `protobuf:"varint,6,rep,name=bit_matrix" json:"bit_matrix,omitempty"`
+	BitMatrix []int32 `protobuf:"varint,7,rep,name=bit_matrix" json:"bit_matrix,omitempty"`
 }
 
 func (m *ReconstructRequest) Reset()         { *m = ReconstructRequest{} }
 func (m *ReconstructRequest) String() string { return proto1.CompactTextString(m) }
 func (*ReconstructRequest) ProtoMessage()    {}
+
+func (m *ReconstructRequest) GetHeader() *RequestHeader {
+	if m != nil {
+		return m.Header
+	}
+	return nil
+}
 
 func (m *ReconstructRequest) GetSrcs() []*ReconstructSrc {
 	if m != nil {

--- a/proto/file.pb.go
+++ b/proto/file.pb.go
@@ -49,7 +49,7 @@ var _ grpc.ClientConn
 var _ = proto1.Marshal
 
 type RequestHeader struct {
-	Client string `protobuf:"bytes,1,opt,name=client" json:"client,omitempty"`
+	ClientID int64 `protobuf:"varint,1,opt,name=clientID" json:"clientID,omitempty"`
 }
 
 func (m *RequestHeader) Reset()         { *m = RequestHeader{} }

--- a/proto/file.proto
+++ b/proto/file.proto
@@ -13,7 +13,7 @@ service cfs {
 
 
 message requestHeader {
-   string client = 1;
+   int64 clientID = 1;
 }
 
 // PathError records an error and the operation and file path that caused it.

--- a/proto/file.proto
+++ b/proto/file.proto
@@ -12,6 +12,10 @@ service cfs {
 }
 
 
+message requestHeader {
+   string client = 1;
+}
+
 // PathError records an error and the operation and file path that caused it.
 message PathError {
     string op = 1;
@@ -45,11 +49,12 @@ message FileInfo {
 // of bytes written and an error, if any.
 // Write returns an error when n != len(b).
 message WriteRequest {
-    string name = 1;
-    int64 offset = 2;
-    bytes data = 3;
-    
-    bool append = 4;
+    requestHeader header = 1;
+    string name = 2;
+    int64 offset = 3;
+    bytes data = 4;
+
+    bool append = 5;
 }
 
 message WriteReply {
@@ -59,10 +64,11 @@ message WriteReply {
 
 // Read reads up to length bytes. The checksum of the data must match the exp_checksum if given, or an error is returned.
 message ReadRequest {
-    string name = 1;
-    int64 offset = 2;
-    int64 length = 3;
-    fixed32 exp_checksum = 4;
+    requestHeader header = 1;
+    string name = 2;
+    int64 offset = 3;
+    int64 length = 4;
+    fixed32 exp_checksum = 5;
 }
 
 message ReadReply {
@@ -73,8 +79,9 @@ message ReadReply {
 }
 
 message RenameRequest {
-    string oldname = 1;
-    string newname = 2;
+    requestHeader header = 1;
+    string oldname = 2;
+    string newname = 3;
 }
 
 message RenameReply {
@@ -82,7 +89,8 @@ message RenameReply {
 }
 
 message ReadDirRequest {
-    string name = 1;
+    requestHeader header = 1;
+    string name = 2;
 }
 
 message ReadDirReply {
@@ -92,10 +100,11 @@ message ReadDirReply {
 
 // Remove removes the named file or directory. If there is an error, it will be of type *PathError.
 message RemoveRequest {
-    string name = 1;
+    requestHeader header = 1;
+    string name = 2;
     // All removes path and any children it contains. It removes everything it can but returns the first error it 
     // encounters. If the path does not exist, RemoveAll returns nil (no error).
-    bool all = 2;
+    bool all = 3;
 }
 
 message RemoveReply {
@@ -105,8 +114,9 @@ message RemoveReply {
 // Mkdir creates a new directory with the specified name. If all is set, Mkdir creates a directory named path,
 // along with any necessary parents. If path is already a directory, Mkdir does nothing.
 message MkdirRequest {
-    string name = 1;
-    bool all = 2;
+    requestHeader header = 1;
+    string name = 2;
+    bool all = 3;
 }
 
 message MkdirReply {
@@ -114,13 +124,15 @@ message MkdirReply {
 }
 
 message ReconstructSrc {
-    string remote = 1;          // remote server (10.10.0.1:15524)
-    string name = 2;
+    requestHeader header = 1;
+    string remote = 2;          // remote server (10.10.0.1:15524)
+    string name = 3;
 }
 
 message ReconstructDst {
+    requestHeader header = 1;
     // The destination should always be local server.
-    string name = 1;
+    string name = 2;
 }
 
 // http://web.eecs.utk.edu/~plank/plank/papers/2013-02-11-FAST-Tutorial.pdf
@@ -128,8 +140,9 @@ message ReconstructDst {
 // Optimized for Cauchy Reed-Solomon (CRS) Codes, but should also be applied to 
 // RAID5 and RAID6
 message ReconstructRequest {
-    repeated ReconstructSrc srcs = 1;
-    repeated ReconstructDst dsts = 2;
+    requestHeader header = 1;
+    repeated ReconstructSrc srcs = 2;
+    repeated ReconstructDst dsts = 3;
 
     // each src has multiple strips. the length of src must be
     // a multiply of stripe_size or it should be zero filled.
@@ -139,16 +152,16 @@ message ReconstructRequest {
     // w MUST be in the range [1, 32]
     //
     // https://www.usenix.org/legacy/events/fast09/tech/full_papers/plank/plank_html Section 2.2
-    int32 strip_size = 3;
-    int32 packet_size = 4;
-    int32 w = 5;
+    int32 strip_size = 4;
+    int32 packet_size = 5;
+    int32 w = 6;
 
     // wk * wn matrix of bits
     // k is the number of sources, n is the number of dests.
     // bit_matrix[i][j] = i * k * w + j
     // TODO: make this a dense bytes array and each bytes contains
     // 8 bits.
-    repeated int32 bit_matrix = 6;
+    repeated int32 bit_matrix = 7;
 }
 
 message ReconstructReply {

--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,7 @@ func (s *server) Write(ctx context.Context, req *pb.WriteRequest) (*pb.WriteRepl
 		return &pb.WriteReply{}, nil
 	}
 
-	stats.Counter("cfs_write_ops_total").Disk(dn).Add()
+	stats.Counter("cfs_write_ops_total").Disk(dn).Client(req.Header.Client).Add()
 	n, err := d.WriteAt(fn, req.Data, req.Offset)
 	// TODO: add error
 	if err != nil {
@@ -55,7 +55,7 @@ func (s *server) Read(ctx context.Context, req *pb.ReadRequest) (*pb.ReadReply, 
 		return &pb.ReadReply{}, nil
 	}
 
-	stats.Counter("cfs_read_ops_total").Disk(dn).Add()
+	stats.Counter("cfs_read_ops_total").Disk(dn).Client(req.Header.Client).Add()
 	// TODO: reuse buffer
 	data := make([]byte, req.Length)
 	n, err := d.ReadAt(fn, data, req.Offset)
@@ -90,7 +90,7 @@ func (s *server) Rename(ctx context.Context, req *pb.RenameRequest) (*pb.RenameR
 		return &pb.RenameReply{}, nil
 	}
 
-	stats.Counter("cfs_rename_ops_total").Disk(dn0).Add()
+	stats.Counter("cfs_rename_ops_total").Disk(dn0).Client(req.Header.Client).Add()
 	err = d.Rename(ofn, nfn)
 	if err != nil {
 		log.Infof("server: rename error (%v)", err)
@@ -113,7 +113,7 @@ func (s *server) Remove(ctx context.Context, req *pb.RemoveRequest) (*pb.RemoveR
 		return &pb.RemoveReply{}, nil
 	}
 
-	stats.Counter("cfs_remove_ops_total").Disk(dn).Add()
+	stats.Counter("cfs_remove_ops_total").Disk(dn).Client(req.Header.Client).Add()
 	err = d.Remove(fn, req.All)
 	if err != nil {
 		log.Infof("server: read error (%v)", err)
@@ -137,7 +137,7 @@ func (s *server) ReadDir(ctx context.Context, req *pb.ReadDirRequest) (*pb.ReadD
 		return reply, nil
 	}
 
-	stats.Counter("cfs_readdir_ops_total").Disk(dn).Add()
+	stats.Counter("cfs_readdir_ops_total").Disk(dn).Client(req.Header.Client).Add()
 	stats, err := d.ReadDir(fn)
 	if err != nil {
 		log.Infof("server: readDir error (%v)", err)
@@ -170,7 +170,7 @@ func (s *server) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb.MkdirRepl
 		log.Infof("server: mkdir error (cannot find disk %s)", dn)
 		return reply, nil
 	}
-	stats.Counter("cfs_mkdir_ops_total").Disk(dn).Add()
+	stats.Counter("cfs_mkdir_ops_total").Disk(dn).Client(req.Header.Client).Add()
 	err = d.Mkdir(fn, req.All)
 	if err != nil {
 		log.Infof("server: mkdir error (%v)", err)

--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,7 @@ func (s *server) Write(ctx context.Context, req *pb.WriteRequest) (*pb.WriteRepl
 		return &pb.WriteReply{}, nil
 	}
 
-	stats.Counter("cfs_write_ops_total").Disk(dn).Client(req.Header.Client).Add()
+	stats.Counter("cfs_write_ops_total").Disk(dn).Client(req.Header.ClientID).Add()
 	n, err := d.WriteAt(fn, req.Data, req.Offset)
 	// TODO: add error
 	if err != nil {
@@ -55,7 +55,7 @@ func (s *server) Read(ctx context.Context, req *pb.ReadRequest) (*pb.ReadReply, 
 		return &pb.ReadReply{}, nil
 	}
 
-	stats.Counter("cfs_read_ops_total").Disk(dn).Client(req.Header.Client).Add()
+	stats.Counter("cfs_read_ops_total").Disk(dn).Client(req.Header.ClientID).Add()
 	// TODO: reuse buffer
 	data := make([]byte, req.Length)
 	n, err := d.ReadAt(fn, data, req.Offset)
@@ -90,7 +90,7 @@ func (s *server) Rename(ctx context.Context, req *pb.RenameRequest) (*pb.RenameR
 		return &pb.RenameReply{}, nil
 	}
 
-	stats.Counter("cfs_rename_ops_total").Disk(dn0).Client(req.Header.Client).Add()
+	stats.Counter("cfs_rename_ops_total").Disk(dn0).Client(req.Header.ClientID).Add()
 	err = d.Rename(ofn, nfn)
 	if err != nil {
 		log.Infof("server: rename error (%v)", err)
@@ -113,7 +113,7 @@ func (s *server) Remove(ctx context.Context, req *pb.RemoveRequest) (*pb.RemoveR
 		return &pb.RemoveReply{}, nil
 	}
 
-	stats.Counter("cfs_remove_ops_total").Disk(dn).Client(req.Header.Client).Add()
+	stats.Counter("cfs_remove_ops_total").Disk(dn).Client(req.Header.ClientID).Add()
 	err = d.Remove(fn, req.All)
 	if err != nil {
 		log.Infof("server: read error (%v)", err)
@@ -137,7 +137,7 @@ func (s *server) ReadDir(ctx context.Context, req *pb.ReadDirRequest) (*pb.ReadD
 		return reply, nil
 	}
 
-	stats.Counter("cfs_readdir_ops_total").Disk(dn).Client(req.Header.Client).Add()
+	stats.Counter("cfs_readdir_ops_total").Disk(dn).Client(req.Header.ClientID).Add()
 	stats, err := d.ReadDir(fn)
 	if err != nil {
 		log.Infof("server: readDir error (%v)", err)
@@ -170,7 +170,7 @@ func (s *server) Mkdir(ctx context.Context, req *pb.MkdirRequest) (*pb.MkdirRepl
 		log.Infof("server: mkdir error (cannot find disk %s)", dn)
 		return reply, nil
 	}
-	stats.Counter("cfs_mkdir_ops_total").Disk(dn).Client(req.Header.Client).Add()
+	stats.Counter("cfs_mkdir_ops_total").Disk(dn).Client(req.Header.ClientID).Add()
 	err = d.Mkdir(fn, req.All)
 	if err != nil {
 		log.Infof("server: mkdir error (%v)", err)

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -16,7 +16,7 @@ func init() {
 
 type CounterType struct {
 	disk   string
-	client string
+	client int64
 	name   string
 }
 
@@ -27,8 +27,8 @@ func (c CounterType) Disk(disk string) CounterType {
 	return c
 }
 
-func (c CounterType) Client(client string) CounterType {
-	c.client = client
+func (c CounterType) Client(id int64) CounterType {
+	c.client = id
 	return c
 }
 
@@ -36,9 +36,6 @@ func (c CounterType) Add() {
 	var prefix string
 	if c.disk != "" {
 		prefix = c.disk + "_"
-	}
-	if c.client != "" {
-		prefix = prefix + c.client + "_"
 	}
 	metrics.Counter(prefix + c.name).Add()
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -2,7 +2,6 @@ package stats
 
 import (
 	"encoding/json"
-	"fmt"
 	"sort"
 	"strconv"
 
@@ -16,8 +15,9 @@ func init() {
 }
 
 type CounterType struct {
-	disk string
-	name string
+	disk   string
+	client string
+	name   string
 }
 
 func Counter(name string) CounterType { return CounterType{name: name} }
@@ -27,12 +27,20 @@ func (c CounterType) Disk(disk string) CounterType {
 	return c
 }
 
+func (c CounterType) Client(client string) CounterType {
+	c.client = client
+	return c
+}
+
 func (c CounterType) Add() {
-	if c.disk == "" {
-		metrics.Counter(c.name).Add()
-	} else {
-		metrics.Counter(fmt.Sprintf("%s_%s", c.disk, c.name)).Add()
+	var prefix string
+	if c.disk != "" {
+		prefix = c.disk + "_"
 	}
+	if c.client != "" {
+		prefix = prefix + c.client + "_"
+	}
+	metrics.Counter(prefix + c.name).Add()
 }
 
 func Server() pb.StatsServer { return &server{} }


### PR DESCRIPTION
Each request has a client name that implies its source. This
is mostly used for metrics and enforcement in more granuality.
