### PR TITLE
*: init docker guide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM progrium/busybox
+
+ADD cfs /
+ADD server/default.conf /
+
+EXPOSE 15524
+ENTRYPOINT ["/cfs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM progrium/busybox
+FROM scratch
 
 ADD cfs /
 ADD server/default.conf /

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,8 @@ proto:
 
 .PHONY: docker
 docker:
-	go build -o cfs -a ${REPO_PATH}/server
+	# Static binary built here may fail to call os/user/lookup functions due to library
+	# conflict. (http://stackoverflow.com/questions/8140439/why-would-it-be-impossible-to-fully-statically-link-an-application)
+	# Because cfs doesn't use these functions, it is ok to ignore the error.
+	go build -a -tags netgo -installsuffix netgo --ldflags '-extldflags "-static"' -o cfs ${REPO_PATH}/server
 	docker build -t c-fs/cfs .

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,8 @@ go-vet:
 .PHONY: proto
 proto:
 	protoc -I proto proto/*.proto --go_out=plugins=grpc:proto
+
+.PHONY: docker
+docker:
+	go build -o cfs -a ${REPO_PATH}/server
+	docker build -t c-fs/cfs .

--- a/README.md
+++ b/README.md
@@ -60,6 +60,26 @@ cfs creates a `/cfs0` disk with root path `/cfs0000` by default.
 
 TODO: make all these configurable.
 
+#### Run Server in a Docker Container
+
+You can run a cfs to provide file service in container easily:
+
+```
+make docker
+
+sudo docker run \
+  --volume=/:/rootfs:ro \
+  --volume=/var/run:/var/run:rw \
+  --volume=/sys:/sys:ro \
+  --volume=/var/lib/docker/:/var/lib/docker:ro \
+  --publish=15524:15524 \
+  --detach=true \
+  --name=cfs \
+  c-fs/cfs
+```
+
+cfs is now running in the background on `http://localhost:15524`. For development, you can replace `--detach=true` with `-ti` to let it run as an interactive process.
+
 #### Write and Read file
 
 ``` bash

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ sudo docker run \
   --volume=/var/run:/var/run:rw \
   --volume=/sys:/sys:ro \
   --volume=/var/lib/docker/:/var/lib/docker:ro \
+  --volume=/tmp:/tmp:rw \
   --publish=15524:15524 \
   --detach=true \
   --name=cfs \


### PR DESCRIPTION
It introduces the basic way to run cfs in a docker.

Following TODO:
1. This guide doesn't support CentOS, Fedora, RHEL(solution: https://github.com/google/cadvisor/blob/master/docs/running.md)
2. Guide about running it in cluster.
3. Add cfsctl into the docker image? Good for test and play, but not good for image size.
4. Make docker run configurable
5. cadvisor in cfs should detect itself in cgroup
