### PR TITLE
server: return data if read to EOF

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io"
+
 	"github.com/c-fs/cfs/disk"
 	pb "github.com/c-fs/cfs/proto"
 	"github.com/c-fs/cfs/stats"
@@ -60,6 +62,10 @@ func (s *server) Read(ctx context.Context, req *pb.ReadRequest) (*pb.ReadReply, 
 	data := make([]byte, req.Length)
 	n, err := d.ReadAt(fn, data, req.Offset)
 	// TODO: add error
+	if err == io.EOF {
+		log.Infof("server: read %d bytes until EOF", n)
+		return &pb.ReadReply{BytesRead: int64(n), Data: data[:n]}, nil
+	}
 	if err != nil {
 		log.Infof("server: read error (%v)", err)
 		return &pb.ReadReply{}, nil


### PR DESCRIPTION
This fixes the example in the guide. In the future, it should return
some error.

Old:

```
client side:
vagrant@ubuntu-14:~/gopath/src/github.com/c-fs/cfs/cfsctl$ ./cfsctl write --name="cfs0/foo" --data="bar"
2015/07/22 05:50:17 [INFO][github.com/c-fs/cfs/cfsctl] write_command.go:41: 3 bytes written to cfs0/foo at offset 0
vagrant@ubuntu-14:~/gopath/src/github.com/c-fs/cfs/cfsctl$ ./cfsctl read --name="cfs0/foo" --length=100
2015/07/22 05:50:20 [INFO][github.com/c-fs/cfs/cfsctl] read_command.go:41:

server side:
2015/07/22 05:50:20 [INFO][github.com/c-fs/cfs/server] server.go:64: server: read error (EOF)
```

New:

```
client side:
vagrant@ubuntu-14:~/gopath/src/github.com/c-fs/cfs/cfsctl$ ./cfsctl read --name="cfs0/foo" --length=10
2015/07/22 08:55:11 [INFO][github.com/c-fs/cfs/cfsctl] read_command.go:41: bar

server side:
2015/07/22 08:55:11 [INFO][github.com/c-fs/cfs/server] server.go:66: server: read 3 bytes until EOF
```

/cc @yunxing 
