### PR TITLE
ack/docker-cluster: add fast way to start local docker cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ _testmain.go
 /server/server
 /server/cfs0000
 /cfsctl/cfsctl
+/hack/docker-cluster/cfs*
 
 # temporary build path
 /proto/gopath

--- a/hack/docker-cluster/Procfile
+++ b/hack/docker-cluster/Procfile
@@ -1,0 +1,5 @@
+# Use goreman to run:
+# `go get github.com/mattn/goreman`
+cfs0: docker run --volume=/:/rootfs:ro --volume=/var/run:/var/run:rw --volume=/sys:/sys:ro --volume=/var/lib/docker/:/var/lib/docker:ro --volume=/tmp:/tmp:rw --volume=${PWD}/cfs0_0:/cfs0_0 --volume=${PWD}/cfs0_1:/cfs0_1 --volume=${PWD}/config:/config --publish=5000:15524 -i --name=cfs0 c-fs/cfs --config=/config/cfs0.conf
+cfs1: docker run --volume=/:/rootfs:ro --volume=/var/run:/var/run:rw --volume=/sys:/sys:ro --volume=/var/lib/docker/:/var/lib/docker:ro --volume=/tmp:/tmp:rw --volume=${PWD}/cfs1_0:/cfs1_0 --volume=${PWD}/cfs1_1:/cfs1_1 --volume=${PWD}/config:/config --publish=5001:15524 -i --name=cfs1 c-fs/cfs --config=/config/cfs1.conf
+cfs2: docker run --volume=/:/rootfs:ro --volume=/var/run:/var/run:rw --volume=/sys:/sys:ro --volume=/var/lib/docker/:/var/lib/docker:ro --volume=/tmp:/tmp:rw --volume=${PWD}/cfs2_0:/cfs2_0 --volume=${PWD}/cfs2_1:/cfs2_1 --volume=${PWD}/config:/config --publish=5002:15524 -i --name=cfs2 c-fs/cfs --config=/config/cfs2.conf

--- a/hack/docker-cluster/cleanup.sh
+++ b/hack/docker-cluster/cleanup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+ 
+docker stop $(docker ps -a -q)
+docker rm $(docker ps -a -q)

--- a/hack/docker-cluster/config/cfs0.conf
+++ b/hack/docker-cluster/config/cfs0.conf
@@ -1,0 +1,24 @@
+# Default Configuration in TOML
+
+################################ GENERAL  #####################################
+
+# Accept connections on the specified port, default is 15524.
+port = "15524"
+
+# By default cfs listens for connections from all the network interfaces
+# available on the server. 
+#
+# Examples:
+#
+# bind = "127.0.0.1"
+
+
+################################ DISKS  #######################################
+
+[[Disks]] 
+name = "cfs0_0"
+root = "cfs0_0"
+
+[[Disks]]
+name = "cfs0_1"
+root = "cfs0_1"

--- a/hack/docker-cluster/config/cfs1.conf
+++ b/hack/docker-cluster/config/cfs1.conf
@@ -1,0 +1,24 @@
+# Default Configuration in TOML
+
+################################ GENERAL  #####################################
+
+# Accept connections on the specified port, default is 15524.
+port = "15524"
+
+# By default cfs listens for connections from all the network interfaces
+# available on the server. 
+#
+# Examples:
+#
+# bind = "127.0.0.1"
+
+
+################################ DISKS  #######################################
+
+[[Disks]] 
+name = "cfs1_0"
+root = "cfs1_0"
+
+[[Disks]]
+name = "cfs1_1"
+root = "cfs1_1"

--- a/hack/docker-cluster/config/cfs2.conf
+++ b/hack/docker-cluster/config/cfs2.conf
@@ -1,0 +1,24 @@
+# Default Configuration in TOML
+
+################################ GENERAL  #####################################
+
+# Accept connections on the specified port, default is 15524.
+port = "15524"
+
+# By default cfs listens for connections from all the network interfaces
+# available on the server. 
+#
+# Examples:
+#
+# bind = "127.0.0.1"
+
+
+################################ DISKS  #######################################
+
+[[Disks]] 
+name = "cfs2_0"
+root = "cfs2_0"
+
+[[Disks]]
+name = "cfs2_1"
+root = "cfs2_1"

--- a/server/main.go
+++ b/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 	"net"
 
@@ -13,15 +14,17 @@ import (
 )
 
 func main() {
-	configfn := "default.conf"
-	data, err := ioutil.ReadFile(configfn)
+	configfn := flag.String("config", "default.conf", "location of configuration file")
+	flag.Parse()
+
+	data, err := ioutil.ReadFile(*configfn)
 	if err != nil {
-		log.Fatalf("server: cannot load configuration file[%s] (%v)", configfn, err)
+		log.Fatalf("server: cannot load configuration file[%s] (%v)", *configfn, err)
 	}
 
 	var conf config.Server
 	if _, err := toml.Decode(string(data), &conf); err != nil {
-		log.Fatalf("server: configuration file[%s] is not valid (%v)", configfn, err)
+		log.Fatalf("server: configuration file[%s] is not valid (%v)", *configfn, err)
 	}
 
 	// default is that cfs is bootstrapped using docker


### PR DESCRIPTION
This displays the way to run multiple cfs fast in docker. And this helps
for further development on reconstruct and copy.

for the first part of #82 

```
vagrant@ubuntu-14:~/gopath/src/github.com/c-fs/cfs/hack/docker-cluster$ sudo /home/vagrant/gopath/bin/goreman start
05:41:02 cfs0 | Starting cfs0 on port 5000
05:41:02 cfs1 | Starting cfs1 on port 5001
05:41:02 cfs2 | Starting cfs2 on port 5002
05:41:03 cfs2 | E0724 05:41:03.003147       1 manager.go:220] Failed to start OOM watcher, will not get OOM events: exec: "journalctl": executable file not found in $PATH
05:41:03 cfs0 | E0724 05:41:03.146837       1 manager.go:220] Failed to start OOM watcher, will not get OOM events: exec: "journalctl": executable file not found in $PATH
05:41:03 cfs1 | E0724 05:41:03.175936       1 manager.go:220] Failed to start OOM watcher, will not get OOM events: exec: "journalctl": executable file not found in $PATH
05:41:03 cfs2 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:36: server: detect docker container "/docker/86b3cdfa68a9600e9142fb157a476bc7a57ae52dd30b9a0a671a2ef3ae335ef6"
05:41:03 cfs2 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:39: server: starting server...
05:41:03 cfs2 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:46: server: listening on :15524
05:41:03 cfs2 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] disk_manage.go:27: server: created disk[cfs2_0] at root path[/cfs2_0]
05:41:03 cfs2 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] disk_manage.go:27: server: created disk[cfs2_1] at root path[/cfs2_1]
05:41:03 cfs2 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:60: server: ready to serve clients
05:41:03 cfs1 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:36: server: detect docker container "/docker/89958b8f806c27d614ff5cd9eb6a5db08726f190f4c3544151c9aba462bee653"
05:41:03 cfs1 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:39: server: starting server...
05:41:03 cfs1 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:46: server: listening on :15524
05:41:03 cfs1 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] disk_manage.go:27: server: created disk[cfs1_0] at root path[/cfs1_0]
05:41:03 cfs1 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] disk_manage.go:27: server: created disk[cfs1_1] at root path[/cfs1_1]
05:41:03 cfs1 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:60: server: ready to serve clients
05:41:03 cfs0 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:36: server: detect docker container "/docker/3d4fbab824c373543fe2e6e50006c649469fb2201e55e70971170377440b5974"
05:41:03 cfs0 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:39: server: starting server...
05:41:03 cfs0 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:46: server: listening on :15524
05:41:03 cfs0 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] disk_manage.go:27: server: created disk[cfs0_0] at root path[/cfs0_0]
05:41:03 cfs0 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] disk_manage.go:27: server: created disk[cfs0_1] at root path[/cfs0_1]
05:41:03 cfs0 | 2015/07/24 05:41:03 [INFO][github.com/c-fs/cfs/server] main.go:60: server: ready to serve clients
^Cvagrant@ubuntu-14:~/gopath/src/github.com/c-fs/cfs/hack/docker-cluster$ sudo ./cleanup.sh
89958b8f806c
86b3cdfa68a9
3d4fbab824c3
89958b8f806c
86b3cdfa68a9
3d4fbab824c3
```
