### PR TITLE
kubernetes-image: init example to deploy on k8s

### DIFF
--- a/kubernetes-image/Dockerfile
+++ b/kubernetes-image/Dockerfile
@@ -1,0 +1,7 @@
+FROM scratch
+
+ADD cfs /
+ADD default.conf /
+
+EXPOSE 15524
+ENTRYPOINT ["/cfs"]

--- a/kubernetes-image/README.md
+++ b/kubernetes-image/README.md
@@ -1,0 +1,49 @@
+# Cloud Native Deployments of cfs using Kubernetes
+
+The following document describes the development of a *cloud native* cfs deployment on Kubernetes. Cloud native deployment indicates application understands that it is running within a cluster manager, and uses this cluster management infrastructure to help implement the application[1].
+
+## Preparation
+
+You should have a Kubernetes cluster running and `kubectl` command line ready. Read [getting started](https://github.com/kubernetes/kubernetes/blob/master/docs/getting-started-guides) for upstream installation instructions.
+
+You should know basics about Kubernetes concepts, including pods, service and replication controller. [Basics tutorials](http://kubernetes.io/v1.0/basicstutorials.html) explain them well.
+
+## Create Single cfs Instance
+
+Create a replication controller for cfs instances. Its default replica count is 1, so it creates single cfs instance in the cluster.
+
+```
+kubectl create -f cfs-controller.yaml
+```
+
+Check replication controller's status and pods' status:
+
+```
+kubectl describe rc cfs
+kubectl describe pods --selector=name=cfs
+```
+
+Check cfs server in the pod is ready:
+[TODO: read and write from one cfs server]
+
+```
+kubectl logs cfs-xxxxx
+```
+
+## Scale up
+
+Scale up cfs instances to 2:
+
+```
+kubectl scale rc cfs --replicas=2
+```
+
+[TODO: read and write from all cfs servers using cfs nameserver]
+
+## Clean up
+
+```
+kubectl delete rc cfs
+```
+
+[1]: https://github.com/kubernetes/kubernetes/tree/master/examples/cassandra

--- a/kubernetes-image/build.sh
+++ b/kubernetes-image/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+ORG_PATH=github.com/c-fs
+REPO_PATH=$ORG_PATH/cfs
+
+go build -a -tags netgo -installsuffix netgo --ldflags '-extldflags "-static"' -o cfs ${REPO_PATH}/server
+docker build -t yunxing/cfs:k8s .
+rm cfs

--- a/kubernetes-image/cfs-controller.yaml
+++ b/kubernetes-image/cfs-controller.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    name: cfs
+  name: cfs
+spec:
+  replicas: 1
+  selector:
+    name: cfs
+  template:
+    metadata:
+      labels:
+        name: cfs
+    spec:
+      containers:
+      - command:
+        - /cfs
+        resources:
+          limits:
+            cpu: 0.1
+        image: yunxing/cfs:k8s
+        name: cfs
+        ports:
+        - containerPort: 15524
+          name: client
+          protocol: TCP
+        volumeMounts:
+        - name: cfs-rootfs
+          mountPath: /rootfs
+          readOnly: true
+        - name: cfs-var-run
+          mountPath: /var/run
+        - name: cfs-sys
+          mountPath: /sys
+          readOnly: true
+        - name: cfs-var-lib-docker
+          mountPath: /var/lib/docker
+          readOnly: true
+        - name: cfs-tmp
+          mountPath: /tmp
+        - name: cfs-data
+          mountPath: /data
+      volumes:
+        - name: cfs-rootfs
+          hostPath:
+            path: /
+        - name: cfs-var-run
+          hostPath:
+            path: /var/run
+        - name: cfs-sys
+          hostPath:
+            path: /sys
+        - name: cfs-var-lib-docker
+          hostPath:
+            path: /var/lib/docker
+        - name: cfs-tmp
+          hostPath:
+            path: /tmp
+        - name: cfs-data
+          emptyDir: {}

--- a/kubernetes-image/default.conf
+++ b/kubernetes-image/default.conf
@@ -1,0 +1,19 @@
+# Default Configuration in TOML
+
+################################ GENERAL  #####################################
+
+# Accept connections on the specified port, default is 15524.
+port = "15524"
+
+# By default cfs listens for connections from all the network interfaces
+# available on the server. 
+#
+# Examples:
+#
+# bind = "127.0.0.1"
+
+
+################################ DISKS  #######################################
+
+[[Disks]] 
+root = "/data"

--- a/server/main.go
+++ b/server/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"flag"
 	"io/ioutil"
+	"math/rand"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -14,6 +16,10 @@ import (
 	"github.com/qiniu/log"
 	"google.golang.org/grpc"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func main() {
 	configfn := flag.String("config", "default.conf", "location of configuration file")
@@ -50,7 +56,11 @@ func main() {
 	cfs := NewServer()
 
 	for _, d := range conf.Disks {
-		err = cfs.AddDisk(d.Name, d.Root)
+		name := d.Name
+		if name == "" {
+			name = strconv.FormatInt(rand.Int63(), 16)
+		}
+		err = cfs.AddDisk(name, d.Root)
 		if err != nil {
 			log.Fatalf("server: failed to add disk (%v)", err)
 		}


### PR DESCRIPTION
This is a init example, and there are many works left, including:
- read/write from the external of cluster
- persist data (we use [emptyDir](https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/volumes.md#emptydir) now)
- restart container, and get the same disk name
- the random-generated disk name is always non-conflicting
- support cfs [volume type](https://github.com/kubernetes/kubernetes/blob/master/docs/user-guide/volumes.md#types-of-volumes) in kubernetes

i have explored the way to 1. write some config in the physical machine 2. start one cfs instance on each physical machine. But each step has the interaction with physical machine, and is hard to do through kubernetes, which hides physical informations.
